### PR TITLE
Fix for black text on iOS 7 and up

### DIFF
--- a/Library/UI/NWLLogView.m
+++ b/Library/UI/NWLLogView.m
@@ -150,6 +150,8 @@
 #if TARGET_OS_IPHONE
     if (![self respondsToSelector:@selector(textStorage)]) {
         self.text = text;
+    } else {
+        [self.textStorage setAttributes:@{UITextAttributeTextColor: self.textColor, UITextAttributeFont: self.font} range:NSMakeRange(0, [text length])];
     }
 #else // TARGET_OS_IPHONE
     self.string = text;


### PR DESCRIPTION
When textStorage is used, the textColor and font have no effect when no
text is set when the view is initialised. Therefore the attributes need
to be set explicitly.
